### PR TITLE
Improve "No Diagrams Available" View

### DIFF
--- a/Apollon/Views/Diagram/DiagramListView.swift
+++ b/Apollon/Views/Diagram/DiagramListView.swift
@@ -15,21 +15,11 @@ struct DiagramListView: View {
                     ImportErrorMessageView(errorMessage: $importErrorMessage)
                 }
                 if diagrams.isEmpty {
-                    Spacer()
-
-                    Text("No diagrams available...")
-                        .foregroundColor(.primary)
-                        .font(.title2)
-                        .bold()
-                        .padding(.horizontal, 20)
-                        .padding(.bottom, 10)
-
-                    Text("Add a new diagram with \(Image(systemName: "plus")) or import a diagram with \(Image(systemName: "square.and.arrow.down")).")
-                        .foregroundColor(ApollonColor.darkGray)
-                        .multilineTextAlignment(.center)
-                        .padding(.horizontal, 20)
-
-                    Spacer()
+                    ContentUnavailableView(
+                        "No Diagrams Available",
+                        systemImage: "rectangle.portrait.on.rectangle.portrait.slash",
+                        description: Text("Add a new diagram with \(Image(systemName: "plus")) or import a diagram with \(Image(systemName: "square.and.arrow.down")).")
+                    )
                 } else {
                     ScrollView(.vertical, showsIndicators: false) {
                         LazyVGrid(columns: [GridItem(.flexible()), GridItem(.flexible())], spacing: 10) {


### PR DESCRIPTION
This PR utilizes the ContentUnavailabeView to show that no diagrams have been created on the home screen.

![Simulator Screenshot - iPhone 15 Pro - 2024-03-04 at 16 10 57](https://github.com/ls1intum/apollon-ios/assets/40467337/45c51c2d-74c4-46a9-bf3b-609e48449ec6)
