### PR TITLE
Fix moving elements not working correctly

### DIFF
--- a/Apollon/Common/Info.plist
+++ b/Apollon/Common/Info.plist
@@ -2,53 +2,14 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>CFBundleDevelopmentRegion</key>
-	<string>$(DEVELOPMENT_LANGUAGE)</string>
-	<key>CFBundleDisplayName</key>
-	<string>$(DISPLAY_NAME)</string>
-	<key>CFBundleExecutable</key>
-	<string>$(EXECUTABLE_NAME)</string>
-	<key>CFBundleIdentifier</key>
-	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
-	<key>CFBundleInfoDictionaryVersion</key>
-	<string>6.0</string>
 	<key>CFBundleLocalizations</key>
 	<array>
 		<string>en</string>
 	</array>
-	<key>CFBundleName</key>
-	<string>$(PRODUCT_NAME)</string>
-	<key>CFBundlePackageType</key>
-	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
-	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
-	<key>CFBundleVersion</key>
-	<string>1</string>
-	<key>LSRequiresIPhoneOS</key>
-	<true/>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>
 		<true/>
 	</dict>
-	<key>UIApplicationSupportsIndirectInputEvents</key>
-	<true/>
-	<key>UILaunchStoryboardName</key>
-	<string>Launch Screen</string>
-	<key>UIRequiredDeviceCapabilities</key>
-	<array>
-		<string>armv7</string>
-	</array>
-	<key>UISupportedInterfaceOrientations</key>
-	<array>
-		<string>UIInterfaceOrientationPortrait</string>
-		<string>UIInterfaceOrientationLandscapeLeft</string>
-		<string>UIInterfaceOrientationLandscapeRight</string>
-		<string>UIInterfaceOrientationPortraitUpsideDown</string>
-	</array>
-	<key>UIUserInterfaceStyle</key>
-	<string>Automatic</string>
-	<key>NSPhotoLibraryAddUsageDescription</key>
-	<string>This allows you to save diagrams to your photo library.</string>
 </dict>
 </plist>

--- a/Apollon/Custom/Modifiers/ExportDiagramModifier.swift
+++ b/Apollon/Custom/Modifiers/ExportDiagramModifier.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 struct ExportDiagramModifier: ViewModifier {
-    @ObservedObject var viewModel: DiagramViewModel
+    var viewModel: DiagramViewModel
     @Binding var isExporting: Bool
 
     func body(content: Content) -> some View {

--- a/Apollon/ViewModels/DiagramViewModel.swift
+++ b/Apollon/ViewModels/DiagramViewModel.swift
@@ -5,15 +5,16 @@ import ApollonView
 import PDFKit
 
 @MainActor
-class DiagramViewModel: ObservableObject {
+@Observable
+class DiagramViewModel {
     /// The locally persisted diagram
-    @Published var diagram: ApollonDiagram
+    var diagram: ApollonDiagram
     /// The exported JSON File
-    @Published var jsonFile: JSONFile?
+    var jsonFile: JSONFile?
     /// The exported PNG Image
-    @Published var pngImage: UIImage?
+    var pngImage: UIImage?
     /// The exported PDF File
-    @Published var pdfFile: URL?
+    var pdfFile: URL?
 
     init(diagram: ApollonDiagram) {
         self.diagram = diagram

--- a/Apollon/Views/Diagram/DiagramDisplayView.swift
+++ b/Apollon/Views/Diagram/DiagramDisplayView.swift
@@ -6,20 +6,34 @@ import ApollonEdit
 struct DiagramDisplayView: View {
     @Environment(\.dismiss) private var dismiss
     @Environment(\.modelContext) private var modelContext
-    @ObservedObject var viewModel: DiagramViewModel
-    @State var diagram: ApollonDiagram
+    @Bindable var viewModel: DiagramViewModel
+    var diagram: ApollonDiagram
+    @State private var model = UMLModel()
     @State private var isExportingDiagram = false
     @State private var isRenamingDiagram = false
     @State private var newDiagramName = ""
+    @State private var id = 0
     
     var body: some View {
         ZStack {
-            ApollonEdit(umlModel: $diagram.model,
+            ApollonEdit(umlModel: $model,
                         diagramType: diagram.diagramType,
                         fontSize: 14.0,
                         themeColor: Color.accentColor,
                         diagramOffset: CGPoint(x: 0, y: 0),
                         isGridBackground: true)
+            .id(id)
+            .onDisappear {
+                diagram.model = model
+                modelContext.insert(diagram)
+                try? modelContext.save()
+            }
+            .onChange(of: diagram.model, initial: true) { oldValue, newValue in
+                let modelEnoded = try? JSONEncoder().encode(diagram.model)
+                let decoded = try? JSONDecoder().decode(UMLModel.self, from: modelEnoded ?? Data())
+                model = decoded ?? .init() // Use empty if re-encoding doesn't work. We're fucked then anyway
+                id += 1
+            }
         }
         .toolbar {
             ToolbarItem(placement: .navigationBarLeading) {
@@ -49,6 +63,7 @@ struct DiagramDisplayView: View {
                         Label("Rename", systemImage: "pencil")
                     }
                     Button {
+                        diagram.model = model
                         viewModel.renderExport()
                         self.isExportingDiagram = true
                     } label: {

--- a/Apollon/Views/Diagram/DiagramListCellView.swift
+++ b/Apollon/Views/Diagram/DiagramListCellView.swift
@@ -5,7 +5,7 @@ import ApollonView
 
 struct DiagramListCellView: View {
     @Environment(\.modelContext) private var modelContext
-    @ObservedObject var viewModel: DiagramViewModel
+    @State var viewModel: DiagramViewModel
     @State var diagram: ApollonDiagram
     @State private var isExportingDiagram = false
     @State private var isRenamingDiagram = false
@@ -13,7 +13,7 @@ struct DiagramListCellView: View {
     
     init(diagram: ApollonDiagram) {
         self.diagram = diagram
-        self._viewModel = ObservedObject(wrappedValue: DiagramViewModel(diagram: diagram))
+        self._viewModel = State(wrappedValue: DiagramViewModel(diagram: diagram))
     }
     
     var body: some View {


### PR DESCRIPTION
This PR fixes an issue where moving elements in a UML model did not work correctly, which caused e.g. attributes of a class to move further than the containing class element.

### Steps for testing
- Create some UML models, if possible using an older version of Apollon on iOS 17
- Open these models in this version (on iOS 18)
- Ensure they are displayed correctly
- Test that you can move and add new elements without issues
- Ensure that changes are saved when going back to the Dashboard